### PR TITLE
[CVE-2023-36617] Upgrade to uri 0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "sentry-ruby"
 gem "simple_twitter", github: "sue445/simple_twitter", branch: "develop"
 
 gem "twitter_oauth2"
+gem "uri", ">= 0.12.2" # for CVE-2023-36617
 
 group :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    uri (0.12.2)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -179,6 +180,7 @@ DEPENDENCIES
   sentry-ruby
   simple_twitter!
   twitter_oauth2
+  uri (>= 0.12.2)
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
ref. https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/