### PR TITLE
Fix deploy error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
-  x86_64-linux
+  x86_64-linux-gnu
 
 DEPENDENCIES
   functions_framework


### PR DESCRIPTION
https://github.com/sue445/pribirthdaybot/actions/runs/13590245164/job/37994362842

```
ERROR: (gcloud.beta.functions.deploy) OperationError: code=3, message=Build failed with status: FAILURE and message: Fetching gem metadata from https://rubygems.org/..........
Your bundle is locked to ffi (1.17.1-x86_64-linux) from rubygems repository
https://rubygems.org/ or installed locally, but that version can no longer be
found in that source. That means the author of ffi (1.17.1-x86_64-linux) has
removed it. You'll need to update your bundle to a version other than ffi
(1.17.1-x86_64-linux) that hasn't been removed in order to install.. For more details see the logs at https://console.cloud.google.com/cloud-build/builds;region=asia-northeast1/09596069-0574-49a8-bac8-9bc5c7127171?project=967853966304.
```